### PR TITLE
fix nested routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,8 @@ function matchRule(location, rule) {
     if (isString(rule.pathname) || rule.search && !isFunction(rule.search)) {
         let ret = {
             pathname: rule.pathname,
-            search: {}
+            search: {},
+            url: window.location.href
         };
         if (rule.pathname && rule.pathname !== location.pathname) {
             ret = null;


### PR DESCRIPTION
Fix: 
从 `#pathName~module=moduleName&page=pageName` 切换到 `#pathName~module=moduleName&page=pageName&subPage=subPageName` 后，再次回到 `#pathName~module=moduleName&page=pageName` 时，无法触发这个 route 的 `onMatch`。